### PR TITLE
Update setup.sh

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -1,5 +1,7 @@
 pip install numpy scipy matplotlib pillow
-pip install easydict opencv-python keras h5py PyYAML
+# set the version of openccv-python if you got an error 
+# when you import cv2
+pip install easydict opencv-python==3.1.0.0 keras h5py PyYAML
 pip install cython==0.24
 
 # for gpu


### PR DESCRIPTION
centos7.4 x64位运行setup.sh会报错，根据setup.sh中的语句逐个安装python包时，遇到opencv与tensorflow冲突，无法导入其中一个包，经测试指定opencv版本可以解决